### PR TITLE
support inputting empty api version

### DIFF
--- a/client.go
+++ b/client.go
@@ -17,7 +17,9 @@ type Client struct {
 // NewClient new fc client
 func NewClient(endpoint, apiVersion, accessKeyID, accessKeySecret string, opts ...ClientOption) (*Client, error) {
 	config := NewConfig()
-	config.APIVersion = apiVersion
+	if apiVersion != "" {
+		config.APIVersion = apiVersion
+	}
 	config.AccessKeyID = accessKeyID
 	config.AccessKeySecret = accessKeySecret
 	config.Endpoint, config.host = GetAccessPoint(endpoint)


### PR DESCRIPTION
There is no any api version information in [aliyun docs](https://help.aliyun.com/product/50980.html) and I don't know what the api version should be, so I think the pr can support inputting an empty apiversion and using the default.